### PR TITLE
docs: avoid using defaultContext() in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ exports.handler = async (event, context) => {
 
   try {
     const browser = await playwright.launchChromium();
-    const context = await browser.defaultContext();
+    const context = await browser.newContext();
 
     const page = await context.newPage();
     await page.goto(event.url || 'https://example.com');


### PR DESCRIPTION
Access to the default context has been removed for all  but `launchPersistent()` modes. People seem to be looking at the example and using private fields as a workaround (see e.g. [this talk](https://egghead.io/lessons/netlify-using-playwright-to-screenshot-the-dom-and-return-an-image-from-a-netlify-function)).