### PR TITLE
enable deploy to lambda layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+%.zip:
+	npm i
+	tsc
+	mkdir -p nodejs/node_modules/playwright-aws-lambda/
+	cd nodejs/ && npm install lambdafs@~1.3.0 playwright-core@~1.3.0 --no-bin-links --no-optional --no-package-lock --no-save --no-shrinkwrap && cd -
+	cp -R ./src/bin/ ./dist/src/bin/
+	npm pack
+	tar --directory nodejs/node_modules/playwright-aws-lambda/ --extract --file playwright-aws-lambda-*.tgz --strip-components=1
+	rm playwright-aws-lambda-*.tgz
+	mkdir -p $(dir $@)
+	zip -9 --filesync --move --recurse-paths $@ nodejs/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ await loadFont(
 );
 ```
 
+### Deploying as lambda layer
+
+Run this command and then publish playwright-aws-lambda.zip on AWS Lambda Layer
+
+```
+git clone --depth=1 https://github.com/JupiterOne/playwright-aws-lambda.git && \
+cd playwright-aws-lambda && \
+make playwright-aws-lambda.zip
+```
+
 ## Thanks / Credits
 
 This project is based on the work of


### PR DESCRIPTION
I made a Makefile to use the same command as chrome-aws-lambda to deploy to lambda layer and update README.md. This changes was tested and works fine on: 

macOS Catalina 10.15.6
npm 6.14.7
typescript 4.0.3